### PR TITLE
Bugfix LSByte will always read 0x00

### DIFF
--- a/index.html
+++ b/index.html
@@ -421,7 +421,6 @@
                 //console.log("Bytes@"+addr+"="+"0x"+v.toString(16).padStart(2, "0"));
             }
 
-
             function refreshFields() {
                 document.getElementById('backlight').value=window.fileByteArray[0xFC];
                 document.getElementById('autoOff').value=window.fileByteArray[0xFB];

--- a/index.html
+++ b/index.html
@@ -416,9 +416,11 @@
 
             function load2ByteROM(addr) {
                 addr_i = parseInt(addr);
-                document.getElementById('TXT_'+addr).value=(window.fileByteArray[addr_i+1] << 8) | window.fileByteArray[addr];
-                //console.log('TXT_'+addr+' ('+addr_i+') -> '+document.getElementById('TXT_'+addr).value);
+                v=(window.fileByteArray[addr_i+1] << 8) | window.fileByteArray[addr_i];
+                document.getElementById('TXT_'+addr).value=v;
+                //console.log("Bytes@"+addr+"="+"0x"+v.toString(16).padStart(2, "0"));
             }
+
 
             function refreshFields() {
                 document.getElementById('backlight').value=window.fileByteArray[0xFC];


### PR DESCRIPTION
Fix a bug mentioned by  @balduinbienlein633 at the comments on https://www.youtube.com/watch?v=px6no-1tb0s "Uni-T UT210E Reparatur und EEPROM-Modifikation"

>vor 3 Jahren
>Prima Eeprom Kalkulator der sehr hilfreich ist um sich in das >Thema einzuarbeiten. Allerdings habe ich einen kleinen Fehler >gefunden. Die Kalibrierdaten für 6A stehen in Adresse 0x50 >0x51. Das LSByte in 0x50 wird nicht gelesen bzw als 00 >verwendet um den Dezimalwert zu berechnen. Gleiches für >den 6000A in 0x56 wo eine Kopie drinsteht von 0x50_

**This bug screws up the calibration values if you modify them.**

**Repro steps:**
- Load a UT210E binary
- Increment a calibration field (e.g., Calibration → Amplifier) by 1
- Save the modified binary
- Reload the saved binary
- Compare the Calibration → Amplifier value with the expected input

**Observed behavior:**
- The loaded value is incorrect — the least significant byte (LSB) was discarded.

You can double check this by utilizing https://devydd.github.io/UT210E-EEPROM-Editor/ for comparison.